### PR TITLE
fix: Support for more kinds of binary headers

### DIFF
--- a/gitdiff/binary.go
+++ b/gitdiff/binary.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+var binaryRegexp = regexp.MustCompile(`^Binary files (/dev/null|a/(.+)|"a/(.+)") and (/dev/null|b/(.+)|"b/(.+)") differ\s*$`)
 
 func (p *parser) ParseBinaryFragments(f *File) (n int, err error) {
 	isBinary, hasData, err := p.ParseBinaryMarker()
@@ -56,7 +59,9 @@ func (p *parser) ParseBinaryMarker() (isBinary bool, hasData bool, err error) {
 	case "Binary files differ\n":
 	case "Files differ\n":
 	default:
-		return false, false, nil
+		if !binaryRegexp.MatchString(p.Line(0)) {
+			return false, false, nil
+		}
 	}
 
 	if err = p.Next(); err != nil && err != io.EOF {

--- a/gitdiff/binary_test.go
+++ b/gitdiff/binary_test.go
@@ -30,6 +30,26 @@ func TestParseBinaryMarker(t *testing.T) {
 			IsBinary: false,
 			HasData:  false,
 		},
+		"binaryPatchCreated": {
+			Input:    "Binary files /dev/null and b/path/to/file.ext differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
+		"binaryPatchModified": {
+			Input:    "Binary files a/path/to/file.ext and b/path/to/file.ext differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
+		"binaryPatchModifiedQuoted": {
+			Input:    "Binary files \"a/path/to/file.ext\" and \"b/path/to/file.ext\" differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
+		"binaryPatchDeleted": {
+			Input:    "Binary files a/path/to/file.ext and /dev/null differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
On my side, `git log` produces the following output for binary files:
```
diff --git a/static/bgfooter.png b/static/bgfooter.png
new file mode 100644
index 000000000..9ce5bdd90
Binary files /dev/null and b/static/bgfooter.png differ
```
(Example taken from https://github.com/celery/celery/commit/d6e46838f980b191e389f57e26c6a31711e817a4.)

`go-gitdiff` currently fails to parse such headers. This change is meant to fix that.