### PR TITLE
fix: Empty name and/or email are valid use cases.

### DIFF
--- a/gitdiff/patch_header.go
+++ b/gitdiff/patch_header.go
@@ -82,9 +82,9 @@ func (i PatchIdentity) String() string {
 }
 
 // ParsePatchIdentity parses a patch identity string. A valid string contains a
-// non-empty name followed by an email address in angle brackets. Like Git,
+// name followed by an email address in angle brackets.
 // ParsePatchIdentity does not require that the email address is valid or
-// properly formatted, only that it is non-empty. The name must not contain a
+// properly formatted. The name must not contain a
 // left angle bracket, '<', and the email address must not contain a right
 // angle bracket, '>'.
 func ParsePatchIdentity(s string) (PatchIdentity, error) {
@@ -108,9 +108,6 @@ func ParsePatchIdentity(s string) (PatchIdentity, error) {
 	}
 	if emailStart > 0 && emailEnd > 0 {
 		email = strings.TrimSpace(s[emailStart:emailEnd])
-	}
-	if name == "" || email == "" {
-		return PatchIdentity{}, fmt.Errorf("invalid identity string: %s", s)
 	}
 
 	return PatchIdentity{Name: name, Email: email}, nil

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -34,11 +34,38 @@ func TestParsePatchIdentity(t *testing.T) {
 		},
 		"missingName": {
 			Input: "<mhaypenny@example.com>",
-			Err:   "invalid identity",
+			Output: PatchIdentity{
+				Name:  "",
+				Email: "mhaypenny@example.com",
+			},
 		},
 		"missingEmail": {
 			Input: "Morton Haypenny",
-			Err:   "invalid identity",
+			Output: PatchIdentity{
+				Name:  "",
+				Email: "",
+			},
+		},
+		"emptyEmail": {
+			Input: "Morton Haypenny <>",
+			Output: PatchIdentity{
+				Name:  "Morton Haypenny",
+				Email: "",
+			},
+		},
+		"missingNameAndEmail": {
+			Input: "",
+			Output: PatchIdentity{
+				Name:  "",
+				Email: "",
+			},
+		},
+		"emptyNameAndEmail": {
+			Input: " <>",
+			Output: PatchIdentity{
+				Name:  "",
+				Email: "",
+			},
 		},
 		"unclosedEmail": {
 			Input: "Morton Haypenny <mhaypenny@example.com",


### PR DESCRIPTION
As a matter of fact, `git` does not fully enforce that name and/or email are non-empty. I don't know how to get there, but as an example, from [hantsy/symfony-rest-sample](https://github.com/hantsy/symfony-rest-sample/commit/6639b2d5316ad1e41a3264199f7a91ba9b13a32d):
```
commit 6639b2d5316ad1e41a3264199f7a91ba9b13a32d
Author:  <>
Date:   Sun Feb 13 09:17:25 2022 +0000

    Deployed 57b0a9f with MkDocs version: 1.2.3
```

Thus, I believe `go-gitdiff` should support this use-case.