### PR TITLE
Add "Binary files .* differ" marker

### DIFF
--- a/gitdiff/binary.go
+++ b/gitdiff/binary.go
@@ -53,11 +53,13 @@ func (p *parser) ParseBinaryFragments(f *File) (n int, err error) {
 }
 
 func (p *parser) ParseBinaryMarker() (isBinary bool, hasData bool, err error) {
-	switch p.Line(0) {
-	case "GIT binary patch\n":
+	line := p.Line(0)
+	switch {
+	case line == "GIT binary patch\n":
 		hasData = true
-	case "Binary files differ\n":
-	case "Files differ\n":
+	case line == "Binary files differ\n":
+	case line == "Files differ\n":
+	case strings.HasPrefix(line, "Binary files ") && strings.HasSuffix(line, "differ\n"):
 	default:
 		if !binaryRegexp.MatchString(p.Line(0)) {
 			return false, false, nil


### PR DESCRIPTION
`git -C <repo> log -p -U0 --full-history --all` using git v2.35.1 will mark binary files with `Binary files <fileA> and <fileB> differ` in the log. Since this does not match any of the existing markers, the binary file will be mismarked and the next header will be read incorrectly.

This PR adds the new marker format to correctly identify binary files.