### PR TITLE
feat: parser should not know about cmd anything

### DIFF
--- a/gitdiff/apply_test.go
+++ b/gitdiff/apply_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
-	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -232,9 +231,7 @@ type applyTest struct {
 func (at applyTest) run(t *testing.T, apply func(io.Writer, *Applier, *File) error) {
 	src, patch, out := at.Files.Load(t)
 
-	cmd := exec.Command("echo", "hello")
-
-	fileChan, err := Parse(cmd, io.NopCloser(bytes.NewReader(patch)))
+	fileChan, err := Parse(io.NopCloser(bytes.NewReader(patch)))
 	if err != nil {
 		t.Fatalf("failed to parse patch file: %v", err)
 	}

--- a/gitdiff/parser_test.go
+++ b/gitdiff/parser_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -503,9 +502,7 @@ Date:   Tue Apr 2 22:55:40 2019 -0700
 				t.Fatalf("unexpected error opening input file: %v", err)
 			}
 
-			cmd := exec.Command("echo", "hello")
-
-			fileChan, err := Parse(cmd, f)
+			fileChan, err := Parse(f)
 			if test.Err {
 				if err == nil || err == io.EOF {
 					t.Fatalf("expected error parsing patch, but got %v", err)
@@ -580,7 +577,7 @@ index ebe9fa54..fe103e1d 100644
 	}
 	for i := 0; i < b.N; i++ {
 		reader := io.NopCloser(strings.NewReader(inputDiff))
-		ch, err := Parse(&exec.Cmd{}, reader)
+		ch, err := Parse(reader)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
In order to fix https://github.com/gitleaks/gitleaks/issues/722 properly we need this patch. In the current state I guess it's a bad practice for parser to know something about implementation.